### PR TITLE
Add uploadable icons to MachineTopology

### DIFF
--- a/src/packages/components/Charts/Mores/MachineTopology/config.ts
+++ b/src/packages/components/Charts/Mores/MachineTopology/config.ts
@@ -1,0 +1,54 @@
+import { echartOptionProfixHandle, PublicConfigClass } from '@/packages/public'
+import { MachineTopologyConfig } from './index'
+import { CreateComponentType } from '@/packages/index.d'
+import cloneDeep from 'lodash/cloneDeep'
+import dataJson from './data.json'
+
+export const includes = []
+
+export const option = {
+  dataset: { ...dataJson },
+  tooltip: {},
+  legend: {
+    show: true,
+    textStyle: {
+      color: '#eee',
+      fontSize: 14
+    },
+    data: dataJson.categories.map(a => a.name)
+  },
+  series: [
+    {
+      type: 'graph',
+      layout: 'none',
+      data: dataJson.nodes,
+      links: dataJson.links,
+      categories: dataJson.categories,
+      label: {
+        show: 1,
+        position: 'right',
+        formatter: '{b}'
+      },
+      labelLayout: {
+        hideOverlap: true
+      },
+      lineStyle: {
+        color: 'source',
+        curveness: 0.2
+      },
+      force: {
+        repulsion: 100,
+        gravity: 0.1,
+        edgeLength: 30,
+        layoutAnimation: 1,
+        friction: 0.6
+      }
+    }
+  ]
+}
+
+export default class Config extends PublicConfigClass implements CreateComponentType {
+  public key = MachineTopologyConfig.key
+  public chartConfig = cloneDeep(MachineTopologyConfig)
+  public option = echartOptionProfixHandle(option, includes)
+}

--- a/src/packages/components/Charts/Mores/MachineTopology/config.vue
+++ b/src/packages/components/Charts/Mores/MachineTopology/config.vue
@@ -1,0 +1,153 @@
+<template>
+  <div>
+    <CollapseItem name="关系图" :expanded="true">
+      <SettingItemBox name="样式">
+        <setting-item name="布局">
+          <n-select v-model:value="graphConfig.layout" :options="GraphLayout" size="small" />
+        </setting-item>
+      </SettingItemBox>
+      <SettingItemBox name="标签">
+        <setting-item name="展示">
+          <n-select v-model:value="graphConfig.label.show" :options="LabelSwitch" size="small" />
+        </setting-item>
+        <setting-item name="位置">
+          <n-select v-model:value="graphConfig.label.position" :options="LabelPosition" size="small" />
+        </setting-item>
+      </SettingItemBox>
+      <SettingItemBox name="线条">
+        <SettingItem name="弧线">
+          <!-- 需要输入两位的小数才会变化 -->
+          <n-input-number
+            v-model:value="optionData.series[0].lineStyle.curveness"
+            :min="0"
+            :step="0.01"
+            placeholder="弯曲程度"
+            size="small"
+          ></n-input-number>
+        </SettingItem>
+      </SettingItemBox>
+      <SettingItemBox name="图例">
+        <SettingItem name="颜色">
+          <n-color-picker
+            size="small"
+            :modes="['hex']"
+            v-model:value="optionData.legend.textStyle.color"
+          ></n-color-picker>
+        </SettingItem>
+        <SettingItem name="文本">
+          <n-input-number
+            v-model:value="optionData.legend.textStyle.fontSize"
+            :min="0"
+            :step="1"
+            size="small"
+            placeholder="文字大小"
+          >
+          </n-input-number>
+        </SettingItem>
+      </SettingItemBox>
+      <SettingItemBox name="力引导" v-if="optionData.series[0].force && graphConfig.layout == 'force'">
+        <SettingItem name="斥力因子" v-if="optionData.series[0].force.repulsion">
+          <n-input-number
+            v-model:value="optionData.series[0].force.repulsion"
+            :min="0"
+            :step="1"
+            size="small"
+            placeholder="斥力因子大小"
+          >
+          </n-input-number>
+        </SettingItem>
+        <SettingItem name="引力因子" v-if="optionData.series[0].force.gravity">
+          <n-input-number
+            v-model:value="optionData.series[0].force.gravity"
+            :min="0"
+            :step="0.1"
+            size="small"
+            placeholder="引力因子"
+          >
+          </n-input-number>
+        </SettingItem>
+        <SettingItem name="节点距离">
+          <n-input-number
+            v-model:value="optionData.series[0].force.edgeLength"
+            :min="0"
+            :step="1"
+            size="small"
+            placeholder="节点距离"
+          >
+          </n-input-number>
+        </SettingItem>
+        <SettingItem name="迭代动画">
+          <n-select v-model:value="graphConfig.force.layoutAnimation" :options="LayoutAnimation" size="small" />
+        </SettingItem>
+      <SettingItem name="节点速度">
+        <n-input-number
+          v-model:value="optionData.series[0].force.friction"
+          :min="0"
+          :step="0.1"
+          size="small"
+          placeholder="节点速度"
+        >
+        </n-input-number>
+      </SettingItem>
+      </SettingItemBox>
+      <SettingItemBox name="节点图标">
+        <setting-item-box
+          v-for="(node, index) in optionData.dataset.nodes"
+          :key="node.id"
+          :name="node.name"
+        >
+          <n-space align="center">
+            <n-input v-model:value="node.symbol" size="small" placeholder="图标地址" />
+            <n-upload :show-file-list="false" :custom-request="opts => iconUpload(opts, index)">
+              <n-button size="small">上传</n-button>
+            </n-upload>
+          </n-space>
+        </setting-item-box>
+      </SettingItemBox>
+    </CollapseItem>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { PropType, computed, nextTick } from 'vue'
+import { CollapseItem, SettingItemBox, SettingItem } from '@/components/Pages/ChartItemSetting'
+import { option, GraphLayout, LabelSwitch, LabelPosition, LayoutAnimation } from './config'
+import { GlobalThemeJsonType } from '@/settings/chartThemes/index'
+import { uploadFile } from '@/api/path/project.api'
+import { ResultEnum } from '@/enums/httpEnum'
+import { UploadCustomRequestOptions } from 'naive-ui'
+import { useSystemStore } from '@/store/modules/systemStore/systemStore'
+
+const props = defineProps({
+  optionData: {
+    type: Object as PropType<typeof option & GlobalThemeJsonType>,
+    required: true
+  }
+})
+
+const graphConfig = computed<(typeof option.series)[0]>(() => {
+  return props.optionData.series[0]
+})
+
+const systemStore = useSystemStore()
+
+const iconUpload = (options: UploadCustomRequestOptions, index: number) => {
+  const { file } = options
+  nextTick(async () => {
+    if (file.file) {
+      const formData = new FormData()
+      formData.append('object', file.file)
+      const uploadRes = await uploadFile(formData)
+      if (uploadRes && uploadRes.code === ResultEnum.SUCCESS) {
+        const url =
+          uploadRes.data.fileurl || `${systemStore.getFetchInfo.OSSUrl || ''}${uploadRes.data.fileName}`
+        props.optionData.dataset.nodes[index].symbol = `image://${url}`
+      } else {
+        window['$message'].error('上传失败，请稍后重试！')
+      }
+    } else {
+      window['$message'].error('上传失败，请稍后重试！')
+    }
+  })
+}
+</script>

--- a/src/packages/components/Charts/Mores/MachineTopology/data.json
+++ b/src/packages/components/Charts/Mores/MachineTopology/data.json
@@ -1,0 +1,43 @@
+{
+  "nodes": [
+    {
+      "id": "A",
+      "name": "Machine A",
+      "symbol": "image://https://naive-ui.oss-cn-beijing.aliyuncs.com/carousel-img/carousel1.jpeg",
+      "symbolSize": 60,
+      "x": 0,
+      "y": 0,
+      "value": 10,
+      "category": 0
+    },
+    {
+      "id": "B",
+      "name": "Machine B",
+      "symbol": "image://https://naive-ui.oss-cn-beijing.aliyuncs.com/carousel-img/carousel2.jpeg",
+      "symbolSize": 60,
+      "x": 200,
+      "y": 0,
+      "value": 10,
+      "category": 1
+    },
+    {
+      "id": "C",
+      "name": "Machine C",
+      "symbol": "image://https://naive-ui.oss-cn-beijing.aliyuncs.com/carousel-img/carousel3.jpeg",
+      "symbolSize": 60,
+      "x": 100,
+      "y": 150,
+      "value": 10,
+      "category": 0
+    }
+  ],
+  "links": [
+    { "source": "A", "target": "B" },
+    { "source": "A", "target": "C" },
+    { "source": "B", "target": "C" }
+  ],
+  "categories": [
+    { "name": "Group1" },
+    { "name": "Group2" }
+  ]
+}

--- a/src/packages/components/Charts/Mores/MachineTopology/index.ts
+++ b/src/packages/components/Charts/Mores/MachineTopology/index.ts
@@ -1,0 +1,14 @@
+import { ConfigType, PackagesCategoryEnum, ChartFrameEnum } from '@/packages/index.d'
+import { ChatCategoryEnum, ChatCategoryEnumName } from '../../index.d'
+
+export const MachineTopologyConfig: ConfigType = {
+  key: 'MachineTopology',
+  chartKey: 'VMachineTopology',
+  conKey: 'VCMachineTopology',
+  title: '拓扑图',
+  category: ChatCategoryEnum.MORE,
+  categoryName: ChatCategoryEnumName.MORE,
+  package: PackagesCategoryEnum.CHARTS,
+  chartFrame: ChartFrameEnum.COMMON,
+  image: 'graph.png'
+}

--- a/src/packages/components/Charts/Mores/MachineTopology/index.vue
+++ b/src/packages/components/Charts/Mores/MachineTopology/index.vue
@@ -1,0 +1,87 @@
+<template>
+  <v-chart
+    ref="vChartRef"
+    :init-options="initOptions"
+    :theme="themeColor"
+    :option="option"
+    :manual-update="isPreview()"
+    autoresize
+  ></v-chart>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, PropType, watch } from 'vue'
+import VChart from 'vue-echarts'
+import { useCanvasInitOptions } from '@/hooks/useCanvasInitOptions.hook'
+import dataJson from './data.json'
+import { use } from 'echarts/core'
+import { CanvasRenderer } from 'echarts/renderers'
+import { RadarChart } from 'echarts/charts'
+import { includes } from './config'
+import { mergeTheme, setOption } from '@/packages/public/chart'
+import { useChartDataFetch } from '@/hooks'
+import { CreateComponentType } from '@/packages/index.d'
+import { useChartEditStore } from '@/store/modules/chartEditStore/chartEditStore'
+import { isPreview } from '@/utils'
+import { DatasetComponent, GridComponent, TooltipComponent, LegendComponent } from 'echarts/components'
+
+const props = defineProps({
+  themeSetting: {
+    type: Object,
+    required: true
+  },
+  themeColor: {
+    type: Object,
+    required: true
+  },
+  chartConfig: {
+    type: Object as PropType<CreateComponentType>,
+    required: true
+  }
+})
+
+const initOptions = useCanvasInitOptions(props.chartConfig.option, props.themeSetting)
+
+use([DatasetComponent, CanvasRenderer, RadarChart, GridComponent, TooltipComponent, LegendComponent])
+
+const vChartRef = ref<typeof VChart>()
+
+const option = computed(() => {
+  return mergeTheme(props.chartConfig.option, props.themeSetting, includes)
+})
+
+const dataSetHandle = (dataset: typeof dataJson) => {
+  if (dataset.nodes) {
+    props.chartConfig.option.series[0].data = dataset.nodes
+  }
+  if (dataset.links) {
+    props.chartConfig.option.series[0].links = dataset.links
+  }
+  if (dataset.categories) {
+    props.chartConfig.option.series[0].categories = dataset.categories
+    // @ts-ignore
+    props.chartConfig.option.legend.data = dataset.categories.map((i: { name: string }) => i.name)
+  }
+  if (vChartRef.value && isPreview()) {
+    setOption(vChartRef.value, props.chartConfig.option)
+  }
+}
+
+watch(
+  () => props.chartConfig.option.dataset,
+  newData => {
+    try {
+      dataSetHandle(newData)
+    } catch (error) {
+      console.log(error)
+    }
+  },
+  {
+    deep: false
+  }
+)
+
+useChartDataFetch(props.chartConfig, useChartEditStore, (newData: typeof dataJson) => {
+  dataSetHandle(newData)
+})
+</script>

--- a/src/packages/components/Charts/Mores/index.ts
+++ b/src/packages/components/Charts/Mores/index.ts
@@ -7,6 +7,7 @@ import { TreeMapConfig } from './TreeMap/index'
 import { DialConfig } from './Dial/index'
 import { SankeyConfig } from './Sankey/index'
 import { GraphConfig } from './Graph/index'
+import { MachineTopologyConfig } from './MachineTopology/index'
 
 export default [
   ProcessConfig,
@@ -16,6 +17,7 @@ export default [
   WaterPoloConfig,
   TreeMapConfig,
   GraphConfig,
+  MachineTopologyConfig,
   SankeyConfig,
   DialConfig
 ]


### PR DESCRIPTION
## Summary
- extend MachineTopology settings panel with upload controls for each node
- remove unused preview image and reuse existing `graph.png`

## Testing
- `pnpm lint` *(fails: ESLint couldn't find config and dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6851283bf8e48330ab1eba87dfc41a42